### PR TITLE
Add TS Linting & Prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# EditorConfig is awesome: http://EditorConfig.org 
+
+# Unix-style newlines with a newline ending every file 
+[*] 
+end_of_line = lf 
+insert_final_newline = true 
+indent_style = space 
+indent_size = 2

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{   
+    "singleQuote": true,   
+    "printWidth": 120,
+    "tabWidth": 2
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "watch:css": "postcss src/styles/index.scss -o src/styles/main.scss -w",
     "lint": "tslint --project .",
     "lint-check": "tslint-config-prettier-check ./tslint.json",
-    "prettier": "prettier-tslint fix"
+    "prettier": "prettier-tslint fix 'src/**/*.{ts,tsx}'"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eject": "react-scripts eject",
     "build:css": "postcss src/styles/index.scss -o src/styles/main.scss",
     "watch:css": "postcss src/styles/index.scss -o src/styles/main.scss -w",
+    "type-check": "yarn tsc --project .",
     "lint": "tslint --project .",
     "lint-check": "tslint-config-prettier-check ./tslint.json",
     "prettier": "prettier-tslint fix 'src/**/*.{ts,tsx}'"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "build:css": "postcss src/styles/index.scss -o src/styles/main.scss",
-    "watch:css": "postcss src/styles/index.scss -o src/styles/main.scss -w"
+    "watch:css": "postcss src/styles/index.scss -o src/styles/main.scss -w",
+    "lint": "tslint --project .",
+    "lint-check": "tslint-config-prettier-check ./tslint.json",
+    "prettier": "prettier-tslint fix"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -39,6 +42,12 @@
   "devDependencies": {
     "autoprefixer": "^9.5.1",
     "postcss-cli": "^6.1.2",
-    "tailwindcss": "^0.7.4"
+    "prettier": "^1.17.0",
+    "prettier-tslint": "^0.4.2",
+    "tailwindcss": "^0.7.4",
+    "tslint": "^5.16.0",
+    "tslint-config-prettier": "^1.18.0",
+    "tslint-microsoft-contrib": "^6.1.1",
+    "tslint-react": "^4.0.0"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import App from './App';
 
 it('renders without crashing', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,20 +5,14 @@ import MergeRequestList from './components/MergeRequest/MergeRequestList';
 import Navbar from './components/Navbar';
 import { MergeRequestType } from './types/MergeRequest';
 
-interface Props {}
-
 interface State {
   mergeRequests: MergeRequestType[];
 }
 
-class App extends Component<Props, State> {
-  public constructor(props: Props) {
-    super(props);
-
-    this.state = {
-      mergeRequests: []
-    };
-  }
+class App extends Component<{}, State> {
+  public state = {
+    mergeRequests: []
+  };
 
   public async componentDidMount() {
     const axiosInstance = axios.create({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
 import axios from 'axios';
-import MergeRequestList from './components/MergeRequest/MergeRequestList';
-import { MergeRequestType } from './types/MergeRequest';
-import Navbar from './components/Navbar';
+import React, { Component } from 'react';
 
-interface Props {
-} 
+import MergeRequestList from './components/MergeRequest/MergeRequestList';
+import Navbar from './components/Navbar';
+import { MergeRequestType } from './types/MergeRequest';
+
+interface Props {}
 
 interface State {
   mergeRequests: MergeRequestType[];
@@ -24,22 +24,22 @@ class App extends Component<Props, State> {
     const axiosInstance = axios.create({
       baseURL: process.env.REACT_APP_GITLAB_URL + '/api/v4',
       timeout: 5000,
-      headers: {'PRIVATE-TOKEN': process.env.REACT_APP_GITLAB_TOKEN}
+      headers: { 'PRIVATE-TOKEN': process.env.REACT_APP_GITLAB_TOKEN }
     });
 
-    let mergeRequestsResponse = await axiosInstance.get('/merge_requests?state=opened&scope=all&order_by=updated_at');
+    const mergeRequestsResponse = await axiosInstance.get('/merge_requests?state=opened&scope=all&order_by=updated_at');
 
     this.setState({
-      'mergeRequests': mergeRequestsResponse.data
+      mergeRequests: mergeRequestsResponse.data
     });
   }
 
   public render() {
-    let { mergeRequests } = this.state ;
+    const { mergeRequests } = this.state;
 
     return (
       <div className="App">
-        <Navbar/>
+        <Navbar />
         <MergeRequestList mergeRequests={mergeRequests} />
       </div>
     );

--- a/src/components/MergeRequest/MergeRequestItem.tsx
+++ b/src/components/MergeRequest/MergeRequestItem.tsx
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
+
 import { MergeRequestType } from '../../types/MergeRequest';
 import Pill from '../Pill';
 
 interface Props {
-    mergeRequest: MergeRequestType;
+  mergeRequest: MergeRequestType;
 }
 
 class MergeRequestItem extends Component<Props> {
@@ -12,15 +13,34 @@ class MergeRequestItem extends Component<Props> {
   };
 
   public render() {
-    let { mergeRequest } = this.props;
+    const { mergeRequest } = this.props;
 
     return (
-        <tr>
-          <td><a className="text-xl no-underline text-black" href={mergeRequest.web_url} target="_blank" rel="noopener noreferrer">{mergeRequest.title}</a></td>
-          <td><img src={mergeRequest.author.avatar_url} alt={mergeRequest.author.name} className="border-2 border-grey h-10 w-10"/></td>
-          <td><Pill text={mergeRequest.upvotes} type={mergeRequest.upvotes > 0 ? "success" : "disable"}/></td>
-          <td><Pill text={mergeRequest.downvotes} type={mergeRequest.downvotes > 0 ? "danger" : "disable"}/></td>
-        </tr>
+      <tr>
+        <td>
+          <a
+            className="text-xl no-underline text-black"
+            href={mergeRequest.web_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {mergeRequest.title}
+          </a>
+        </td>
+        <td>
+          <img
+            src={mergeRequest.author.avatar_url}
+            alt={mergeRequest.author.name}
+            className="border-2 border-grey h-10 w-10"
+          />
+        </td>
+        <td>
+          <Pill text={mergeRequest.upvotes} type={mergeRequest.upvotes > 0 ? 'success' : 'disable'} />
+        </td>
+        <td>
+          <Pill text={mergeRequest.downvotes} type={mergeRequest.downvotes > 0 ? 'danger' : 'disable'} />
+        </td>
+      </tr>
     );
   }
 }

--- a/src/components/MergeRequest/MergeRequestList.tsx
+++ b/src/components/MergeRequest/MergeRequestList.tsx
@@ -1,11 +1,13 @@
+import { faThumbsDown, faThumbsUp } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { Component } from 'react';
-import MergeRequestItem from './MergeRequestItem';
+
 import { MergeRequestType } from '../../types/MergeRequest';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faThumbsUp, faThumbsDown } from '@fortawesome/free-solid-svg-icons'
+
+import MergeRequestItem from './MergeRequestItem';
 
 interface Props {
-    mergeRequests: MergeRequestType[];
+  mergeRequests: MergeRequestType[];
 }
 
 class MergeRequestList extends Component<Props> {
@@ -14,25 +16,29 @@ class MergeRequestList extends Component<Props> {
   };
 
   public tabs = [
-    'Title', 
-    'Author', 
-    <FontAwesomeIcon icon={faThumbsUp} size="sm" className="text-green-dark"/>, 
-    <FontAwesomeIcon icon={faThumbsDown} size="sm" className="text-red-dark"/>
+    'Title',
+    'Author',
+    <FontAwesomeIcon icon={faThumbsUp} size="sm" className="text-green-dark" />,
+    <FontAwesomeIcon icon={faThumbsDown} size="sm" className="text-red-dark" />
   ];
 
   public render() {
-    let { mergeRequests } = this.props;
+    const { mergeRequests } = this.props;
 
-    const listItems = mergeRequests.map((mergeRequest: MergeRequestType) =>
+    const listItems = mergeRequests.map((mergeRequest: MergeRequestType) => (
       <MergeRequestItem key={mergeRequest.id} mergeRequest={mergeRequest} />
-    );
+    ));
 
     return (
       <div className="ml-4">
         <table className="w-full">
           <thead className="text-2xl mb-5">
             <tr>
-              { this.tabs.map((tab, index) => <th key={index} className="py-4" align="left">{tab}</th>)}
+              {this.tabs.map((tab, index) => (
+                <th key={index} className="py-4" align="left">
+                  {tab}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>{listItems}</tbody>

--- a/src/components/MergeRequest/MergeRequestList.tsx
+++ b/src/components/MergeRequest/MergeRequestList.tsx
@@ -15,13 +15,6 @@ class MergeRequestList extends Component<Props> {
     mergeRequests: []
   };
 
-  public tabs = [
-    'Title',
-    'Author',
-    <FontAwesomeIcon icon={faThumbsUp} size="sm" className="text-green-dark" />,
-    <FontAwesomeIcon icon={faThumbsDown} size="sm" className="text-red-dark" />
-  ];
-
   public render() {
     const { mergeRequests } = this.props;
 
@@ -34,11 +27,18 @@ class MergeRequestList extends Component<Props> {
         <table className="w-full">
           <thead className="text-2xl mb-5">
             <tr>
-              {this.tabs.map((tab, index) => (
-                <th key={index} className="py-4" align="left">
-                  {tab}
-                </th>
-              ))}
+              <th>
+                Title
+              </th>
+              <th>
+                Author
+              </th>
+              <th>
+                <FontAwesomeIcon icon={faThumbsUp} size="sm" className="text-green-dark" />
+              </th>
+              <th>
+                <FontAwesomeIcon icon={faThumbsDown} size="sm" className="text-red-dark" />
+              </th>
             </tr>
           </thead>
           <tbody>{listItems}</tbody>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ class Navbar extends Component {
     return (
       <nav className="flex items-center justify-between flex-wrap bg-blue-darkest p-6">
         <div className="text-white mr-6">
-          <a className="text-white no-underline" href="" onClick={() => window.location.reload()}>
+          <a className="text-white no-underline" href="" onClick={window.location.reload}>
             <h1 className="font-semibold text-3xl tracking-tight">GitLab Reviewer</h1>
           </a>
         </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,23 +1,28 @@
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { Component } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faGithub } from '@fortawesome/free-brands-svg-icons'
 
 class Navbar extends Component {
   public render() {
     return (
-        <nav className="flex items-center justify-between flex-wrap bg-blue-darkest p-6">
-            <div className="text-white mr-6">
-                <a className="text-white no-underline" href="" onClick={() => window.location.reload()}>
-                    <h1 className="font-semibold text-3xl tracking-tight">GitLab Reviewer</h1>
-                </a>
-            </div>
-            <div>
-                <a className="text-white hover:text-grey no-underline flex " href="https://github.com/TheGrowingPlant/gitlab-reviewer" target="_blank" rel="noopener noreferrer">
-                    <p className="pr-2 pt-1">Fork me on</p>
-                    <FontAwesomeIcon icon={faGithub} size="2x" className="text-white hover:text-grey"/>
-                </a>
-            </div>
-        </nav>
+      <nav className="flex items-center justify-between flex-wrap bg-blue-darkest p-6">
+        <div className="text-white mr-6">
+          <a className="text-white no-underline" href="" onClick={() => window.location.reload()}>
+            <h1 className="font-semibold text-3xl tracking-tight">GitLab Reviewer</h1>
+          </a>
+        </div>
+        <div>
+          <a
+            className="text-white hover:text-grey no-underline flex "
+            href="https://github.com/TheGrowingPlant/gitlab-reviewer"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <p className="pr-2 pt-1">Fork me on</p>
+            <FontAwesomeIcon icon={faGithub} size="2x" className="text-white hover:text-grey" />
+          </a>
+        </div>
+      </nav>
     );
   }
 }

--- a/src/components/Pill.tsx
+++ b/src/components/Pill.tsx
@@ -1,37 +1,37 @@
 import React, { Component } from 'react';
 
 interface Props {
-    text: string | number;
-    type: "success" | "danger" | "disable";
+  text: string | number;
+  type: 'success' | 'danger' | 'disable';
 }
 
 class Pill extends Component<Props> {
   private getStyleFromType() {
     const { type } = this.props;
-    
+
     switch (type) {
-        case "success":{
-            return "bg-green hover:bg-green-dark text-white";
-        }
-        case "danger":{
-            return "bg-red hover:bg-red-dark text-white";
-        }
-        case "disable":{
-            return "bg-grey hover:bg-grey-dark text-white";
-        }
-        default:{
-            return "bg-grey hover:bg-grey-dark text-white";
-        }
+      case 'success': {
+        return 'bg-green hover:bg-green-dark text-white';
+      }
+      case 'danger': {
+        return 'bg-red hover:bg-red-dark text-white';
+      }
+      case 'disable': {
+        return 'bg-grey hover:bg-grey-dark text-white';
+      }
+      default: {
+        return 'bg-grey hover:bg-grey-dark text-white';
+      }
     }
   }
 
   public render() {
-    let { text } = this.props;
-    
+    const { text } = this.props;
+
     return (
-        <div className={"font-bold h-8 w-8 rounded-full flex items-center justify-center " + this.getStyleFromType()}>
-          <p>{text}</p>
-        </div>
+      <div className={'font-bold h-8 w-8 rounded-full flex items-center justify-center ' + this.getStyleFromType()}>
+        <p>{text}</p>
+      </div>
     );
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './styles/main.scss';
+
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import './styles/main.scss';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -15,23 +15,18 @@ const isLocalhost = Boolean(
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||
     // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 );
 
-type Config = {
+interface Config {
   onSuccess?: (registration: ServiceWorkerRegistration) => void;
   onUpdate?: (registration: ServiceWorkerRegistration) => void;
-};
+}
 
 export function register(config?: Config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(
-      (process as { env: { [key: string]: string } }).env.PUBLIC_URL,
-      window.location.href
-    );
+    const publicUrl = new URL((process as { env: { [key: string]: string } }).env.PUBLIC_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
@@ -112,10 +107,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get('content-type');
-      if (
-        response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
-      ) {
+      if (response.status === 404 || (contentType != null && contentType.indexOf('javascript') === -1)) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then(registration => {
           registration.unregister().then(() => {
@@ -128,9 +120,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       }
     })
     .catch(() => {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      );
+      console.log('No internet connection found. App is running in offline mode.');
     });
 }
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -43,12 +43,14 @@ export function register(config?: Config) {
 
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
+        /*
         navigator.serviceWorker.ready.then(() => {
           console.log(
             'This web app is being served cache-first by a service ' +
               'worker. To learn more, visit https://bit.ly/CRA-PWA'
           );
         });
+        */
       } else {
         // Is not localhost. Just register service worker
         registerValidSW(swUrl, config);
@@ -72,10 +74,13 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
+
+              /*
               console.log(
                 'New content is available and will be used when all ' +
                   'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
               );
+              */
 
               // Execute callback
               if (config && config.onUpdate) {
@@ -85,7 +90,8 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              
+              // console.log('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -97,7 +103,8 @@ function registerValidSW(swUrl: string, config?: Config) {
       };
     })
     .catch(error => {
-      console.error('Error during service worker registration:', error);
+      // console.error('Error during service worker registration:', error);
+      return null;
     });
 }
 
@@ -120,7 +127,8 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       }
     })
     .catch(() => {
-      console.log('No internet connection found. App is running in offline mode.');
+      // console.log('No internet connection found. App is running in offline mode.');
+      return null;
     });
 }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -20,6 +20,10 @@ code {
 }
 
 tr {
+  th {
+    @apply .py-4 .text-left;
+  }
+  
   td {
     @apply .py-2;
   }

--- a/src/types/MergeRequest.d.ts
+++ b/src/types/MergeRequest.d.ts
@@ -67,7 +67,7 @@ export interface MergeRequestType {
     total_time_spent: number;
     human_time_estimate: number;
     human_total_time_spent: number;
-  },
+  };
   squash: boolean;
   approvals_before_merge: number | null;
 }

--- a/tslint.json
+++ b/tslint.json
@@ -2,8 +2,8 @@
     "defaultSeverity": "error",
     "extends": [
         "tslint:recommended",
-        "tslint-config-prettier",
-        "tslint-react"
+        "tslint-react",
+        "tslint-config-prettier"
     ],
     "jsRules": {},
     "rules": {
@@ -19,15 +19,11 @@
         "jsx-boolean-value": false,
         "jsx-equals-spacing": false,
         "jsx-no-bind": true,
-        "jsx-no-lambda": true,
-        "jsx-no-multiline-js": false,
-        "jsx-wrap-multiline": true,        
+        "jsx-no-lambda": true, 
         "jsx-self-close": true,
-        "jsx-space-before-trailing-slash": true,
         "no-relative-imports": true,
         "no-var-requires": false,
-        "no-any": true,
-        "member-ordering": false
+        "no-any": false
     },
     "linterOptions": {
         "exclude": [

--- a/tslint.json
+++ b/tslint.json
@@ -21,7 +21,7 @@
         "jsx-no-bind": true,
         "jsx-no-lambda": true, 
         "jsx-self-close": true,
-        "no-relative-imports": true,
+        "no-relative-imports": false,
         "no-var-requires": false,
         "member-ordering": false,
         "no-any": false

--- a/tslint.json
+++ b/tslint.json
@@ -23,6 +23,7 @@
         "jsx-self-close": true,
         "no-relative-imports": true,
         "no-var-requires": false,
+        "member-ordering": false,
         "no-any": false
     },
     "linterOptions": {

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,7 @@
         "no-relative-imports": false,
         "no-var-requires": false,
         "member-ordering": false,
-        "no-any": false
+        "no-any": true
     },
     "linterOptions": {
         "exclude": [

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,41 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended",
+        "tslint-config-prettier",
+        "tslint-react"
+    ],
+    "jsRules": {},
+    "rules": {
+        "quotemark": false,
+        "object-literal-sort-keys": false,
+        "ordered-imports": [
+            true,
+            {
+                "grouped-imports": true
+            }
+        ],        
+        "interface-name": false,
+        "jsx-boolean-value": false,
+        "jsx-equals-spacing": false,
+        "jsx-no-bind": true,
+        "jsx-no-lambda": true,
+        "jsx-no-multiline-js": false,
+        "jsx-wrap-multiline": true,        
+        "jsx-self-close": true,
+        "jsx-space-before-trailing-slash": true,
+        "no-relative-imports": true,
+        "no-var-requires": false,
+        "no-any": true,
+        "member-ordering": false
+    },
+    "linterOptions": {
+        "exclude": [
+            "*.json",
+            "**/*.json"
+        ]
+    },
+    "rulesDirectory": [
+        "node_modules/tslint-microsoft-contrib"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2186,6 +2186,11 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+builtin-modules@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -2348,7 +2353,7 @@ ccount@^1.0.3:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
   integrity sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2597,6 +2602,11 @@ commander@^2.11.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+commander@^2.12.1:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 comment-regex@^1.0.0:
   version "1.0.1"
@@ -4474,7 +4484,7 @@ globals@^9.18.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
-globby@8.0.2:
+globby@8.0.2, globby@^8.0.1:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
   integrity sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==
@@ -4905,7 +4915,7 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.5:
+ignore@^3.3.5, ignore@^3.3.7:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
@@ -5892,6 +5902,14 @@ js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.2"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
   integrity sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.13.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -8193,6 +8211,23 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier-tslint@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/prettier-tslint/-/prettier-tslint-0.4.2.tgz#37dd009ad6a482ea8101f40cf70b777bc86f3438"
+  integrity sha512-urhX7U/F+fu8sztEs/Z7CxNS8PdEytEwGKhQaH5fxxCdRmHGT45FoClyDlcZrMk9cK/8JpX/asFmTOHtSGJfLg==
+  dependencies:
+    chalk "^2.4.0"
+    globby "^8.0.1"
+    ignore "^3.3.7"
+    require-relative "^0.8.7"
+    tslint "^5.9.1"
+    yargs "^11.0.0"
+
+prettier@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
+  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
+
 pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
@@ -8865,6 +8900,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
+
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+  integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
 
 requires-port@^1.0.0:
   version "1.0.0"
@@ -9974,10 +10014,69 @@ ts-pnp@^1.0.0:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.0.1.tgz#fde74a6371676a167abaeda1ffc0fdb423520098"
   integrity sha512-Zzg9XH0anaqhNSlDRibNC8Kp+B9KNM0uRIpLpGkGyrgRIttA7zZBhotTSEoEyuDrz3QW2LGtu2dxuk34HzIGnQ==
 
-tslib@^1.9.0:
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslint-config-prettier@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
+  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
+
+tslint-microsoft-contrib@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.1.1.tgz#1de9b5c2867f6cec762bab9d8e1619f2b8eb59fc"
+  integrity sha512-u6tK+tgt8Z1YRJxe4kpWWEx/6FTFxdga50+osnANifsfC7BMzh8c/t/XbNntTRiwMfpHkQ9xtUjizCDLxN1Yeg==
+  dependencies:
+    tsutils "^2.27.2 <2.29.0"
+
+tslint-react@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-4.0.0.tgz#b4bb4c01c32448cb14d23f143a2f5e4989bb961e"
+  integrity sha512-9fNE0fm9zNDx1+b6hgy8rgDN2WsQLRiIrn3+fbqm0tazBVF6jiaCFAITxmU+WSFWYE03Xhp1joCircXOe1WVAQ==
+  dependencies:
+    tsutils "^3.9.1"
+
+tslint@^5.16.0, tslint@^5.9.1:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.16.0.tgz#ae61f9c5a98d295b9a4f4553b1b1e831c1984d67"
+  integrity sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.13.0"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.29.0"
+
+"tsutils@^2.27.2 <2.29.0":
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.28.0.tgz#6bd71e160828f9d019b6f4e844742228f85169a1"
+  integrity sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^2.29.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.9.1:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.10.0.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
+  integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Fixes 8#

# Changes : 
* Install prettier and tslint packages
* Extends Microsoft tslint recommendations and tslint-react
* Add commands to lint, check types and fix linting errors in project
* Fix remaining issues not auto corrected
* Add .editorconfig file

I think `no-any` will help us in improving our usage of Typescript 

Couldn't add `non-relative-import` as it is currently not supported by create-react-app, but soon will be supported in react-scripts 3.0 https://github.com/facebook/create-react-app/issues/5645

I don't know how to setup pre-commit