### PR TITLE
Add PurgeCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "@fullhuman/postcss-purgecss": "^1.3.0",
     "@types/favico.js": "^0.0.28",
     "autoprefixer": "^9.7.0",
     "postcss-cli": "^6.1.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,13 @@
 const tailwindcss = require('tailwindcss');
+const purgecss = require('@fullhuman/postcss-purgecss');
 
 module.exports = {
     plugins: [
         tailwindcss('./tailwind.config.js'),
         require('autoprefixer'),
+        purgecss({
+          content: ['public/index.html', 'src/**/*.tsx'],
+          defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
+        }),
     ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,6 +1067,14 @@
   dependencies:
     prop-types "^15.5.10"
 
+"@fullhuman/postcss-purgecss@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-1.3.0.tgz#d632900d818f4fcf4678e7326923fb838c3e03a7"
+  integrity sha512-zvfS3dPKD2FAtMcXapMJXGbDgEp9E++mLR6lTgSruv6y37uvV5xJ1crVktuC1gvnmMwsa7Zh1m05FeEiz4VnIQ==
+  dependencies:
+    postcss "^7.0.14"
+    purgecss "^1.4.0"
+
 "@hapi/address@2.x.x":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.2.tgz#1c794cd6dbf2354d1eb1ef10e0303f573e1c7222"
@@ -8850,6 +8858,16 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+purgecss@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-1.4.0.tgz#79905624ec1c6c8e1f03044bca92dd8a598ba429"
+  integrity sha512-or7/16i7O6DH+NpXqY8NCcWCc940O6PxOgjWAcMTElzgccKOJua1/n6JVtM8UYqoMMWoCyKk+CbLpo4+4mY3BQ==
+  dependencies:
+    glob "^7.1.3"
+    postcss "^7.0.14"
+    postcss-selector-parser "^6.0.0"
+    yargs "^14.0.0"
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -11445,6 +11463,14 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
+  integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
@@ -11528,6 +11554,23 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^14.0.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.0.tgz#f116a9242c4ed8668790b40759b4906c276e76c3"
+  integrity sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.0"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
This is an attempt to reduce css size by removing all unused classes.

Before:

```
File sizes after gzip:

  114.1 KB  build/static/js/2.ee8b99e2.chunk.js
  78.74 KB  build/static/css/main.9b4f3d7a.chunk.css
  4.43 KB   build/static/js/main.c5babfb5.chunk.js
  777 B     build/static/js/runtime-main.b14c66be.js
```

After:

```
File sizes after gzip:

  114.1 KB             build/static/js/2.ee8b99e2.chunk.js
  4.43 KB              build/static/js/main.c5babfb5.chunk.js
  1.76 KB (-76.98 KB)  build/static/css/main.e5d1668d.chunk.css
  777 B                build/static/js/runtime-main.b14c66be.js
```

But, there always be a counterpart with this kind of tool, we must be aware of this: https://tailwindcss.com/docs/controlling-file-size/#writing-purgeable-html.

Should I activate purgecss only for production build?